### PR TITLE
feat: use a compact string for label names and values

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,6 +48,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
+name = "castaway"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0abae9be0aaf9ea96a3b1b8b1b55c602ca751eba1b1500220cea4ecbafe7c0d5"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -104,6 +113,21 @@ name = "clap_lex"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+
+[[package]]
+name = "compact_str"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "serde",
+ "static_assertions",
+]
 
 [[package]]
 name = "criterion"
@@ -360,6 +384,7 @@ dependencies = [
 name = "prometheus_client_python_speedups"
 version = "0.1.0"
 dependencies = [
+ "compact_str",
  "criterion",
  "hashbrown",
  "pyo3",
@@ -540,6 +565,12 @@ dependencies = [
  "ryu",
  "serde",
 ]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ name = "prometheus_client_python_speedups"
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
+compact_str = { version = "0.8.1", features = ["serde"] }
 hashbrown = "0.15.2"
 pyo3 = "0.23.3"
 serde = { version = "1.0.217", features = ["derive"] }

--- a/src/compact_string.rs
+++ b/src/compact_string.rs
@@ -1,0 +1,62 @@
+//! A compact string representation for use with label names and values.
+//!
+//! Label names and values are commonly small strings, which can be stored
+//! efficiently on the stack if they are below a certain size. This module
+//! provides the [`CompactString`] type which makes use of this optimization
+//! to avoid having to heap allocate in the common case.
+//!
+//! The current implementation effectively reuses [`compact_str::CompactString`].
+//! We use a newtype wrapper so we can implement the required pyo3 traits and
+//! to make it easier to modify later if we need to.
+
+use pyo3::{prelude::*, types::PyString};
+use serde::{Deserialize, Serialize};
+
+/// Wrapper around a [`compact_str::CompactString`] which also implements
+/// [`pyo3::IntoPyObject`].
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Deserialize, Serialize)]
+pub struct CompactString(compact_str::CompactString);
+
+impl CompactString {
+    /// Create a new [`CompactString`] from a static string.
+    pub const fn const_new(s: &'static str) -> Self {
+        Self(compact_str::CompactString::const_new(s))
+    }
+
+    /// Create a new [`CompactString`] from a string slice.
+    pub fn new(s: &str) -> Self {
+        Self(compact_str::CompactString::new(s))
+    }
+}
+
+impl From<compact_str::CompactString> for CompactString {
+    fn from(s: compact_str::CompactString) -> Self {
+        Self(s)
+    }
+}
+
+impl std::ops::Deref for CompactString {
+    type Target = compact_str::CompactString;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl std::borrow::Borrow<str> for CompactString {
+    fn borrow(&self) -> &str {
+        &self.0
+    }
+}
+
+impl<'py> IntoPyObject<'py> for CompactString {
+    type Target = PyString;
+
+    type Output = Bound<'py, Self::Target>;
+
+    type Error = std::convert::Infallible;
+
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        self.as_str().into_pyobject(py)
+    }
+}


### PR DESCRIPTION
Label names and values are commonly small strings, which can be stored
efficiently on the stack if they are below a certain size. This module
provides the `CompactString` type which makes use of this optimization
to avoid having to heap allocate in the common case.

The current implementation effectively reuses
`compact_str::CompactString`. We use a newtype wrapper so we can
implement the required pyo3 traits and to make it easier to modify
later if we need to.

This gets us a decent speedup in the benchmark:

```
❯ cargo bench
   ...
     Running benches/my_benchmark.rs (target/release/deps/my_benchmark-81bd16a5775629d5)
merge_internal          time:   [75.765 µs 75.840 µs 75.922 µs]
                        change: [-23.539% -23.365% -23.161%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  5 (5.00%) high mild
  5 (5.00%) high severe
```
